### PR TITLE
Use UTC instead of local time as the sample time

### DIFF
--- a/cloudhistory/files/readinsertinstances.py
+++ b/cloudhistory/files/readinsertinstances.py
@@ -12,7 +12,7 @@ import StringIO
 from xml.etree.ElementTree import iterparse
 import argparse
 
-sampledatetime = datetime.datetime.now()
+sampledatetime = datetime.datetime.utcnow()
 #print "sampledatetime: ",sampledatetime
 
 parser = argparse.ArgumentParser()


### PR DESCRIPTION
Hello!

Current implementation leaves curious two hour gaps in Finland between launchtime and sampledatetime. Replacing datetime.now here with utcnow, which resolves the situation.